### PR TITLE
Update thermal model

### DIFF
--- a/nrel/routee/transit/thermal_energy.py
+++ b/nrel/routee/transit/thermal_energy.py
@@ -115,8 +115,10 @@ def load_thermal_lookup_table() -> pd.DataFrame:
 
 
 def compute_HVAC_energy(
-    start_hours: pd.Series, end_hours: pd.Series, power_array: np.ndarray
-) -> np.ndarray:
+    start_hours: pd.Series,
+    end_hours: pd.Series,
+    power_array: np.typing.NDArray[np.number],
+) -> np.typing.NDArray[np.number]:
     """
     Calculate HVAC + BTMS energy consumption between time intervals.
 


### PR DESCRIPTION
* Fix bug when stop locations were outside of county boundaries, making no TMY data available (and looking for a nonexistent `nan.csv` file.) Solves #49
* Refactor thermal_impacts.py into smaller functions
* Add ability to predict thermal load for median day (instead of just hottest and coldest days)
* Changes to output format to handle the additional weather scenario. Now instead of adding `Winter_HVAC_Energy` and `Summer_HVAC_Energy` columns to the predictions, we add `scenario` (e.g., `median`) and `hvac_energy` columns.