### PR TITLE
Add agency locations to agencies table when gathering feeds

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -13138,8 +13138,8 @@ packages:
   requires_python: '>=3.6.9'
 - pypi: ./
   name: routee-transit
-  version: 0.3.0
-  sha256: 5bab382ada704337e0876fbfd8eb3f8d07ce596d85869c93796a528451c8114e
+  version: 0.3.1
+  sha256: 6074e194bf0e18e5217cb1bdfd3496ff19bc1cda4da5ea1a14b8ca1353ddd09c
   requires_dist:
   - pandas>=2.3.3,<3
   - gtfsblocks>=0.1.5,<0.2

--- a/scripts/feeds/extract_static_gtfs.py
+++ b/scripts/feeds/extract_static_gtfs.py
@@ -99,9 +99,7 @@ class GtfsExtractor:
 
     def query_mdb_feed_datasets(self, feed_id: str) -> List[Dict[str, Any]]:
         """Query all datasets for a GTFS feed, sorted newest to oldest."""
-        result = self.query_mobility_db(
-            path=f"gtfs_feeds/{feed_id}/datasets", query=""
-        )
+        result = self.query_mobility_db(path=f"gtfs_feeds/{feed_id}/datasets", query="")
         if not isinstance(result, list):
             raise TypeError(
                 f"Expected list from feed datasets endpoint, got {type(result)}"

--- a/scripts/feeds/extract_static_gtfs.py
+++ b/scripts/feeds/extract_static_gtfs.py
@@ -97,6 +97,17 @@ class GtfsExtractor:
             raise TypeError(f"Expected dict from dataset endpoint, got {type(result)}")
         return result
 
+    def query_mdb_feed_datasets(self, feed_id: str) -> List[Dict[str, Any]]:
+        """Query all datasets for a GTFS feed, sorted newest to oldest."""
+        result = self.query_mobility_db(
+            path=f"gtfs_feeds/{feed_id}/datasets", query=""
+        )
+        if not isinstance(result, list):
+            raise TypeError(
+                f"Expected list from feed datasets endpoint, got {type(result)}"
+            )
+        return result
+
     def make_api_request(
         self, url: str, headers: Dict[str, str], timeout: int = 60
     ) -> requests.Response:

--- a/scripts/feeds/gather_feeds.py
+++ b/scripts/feeds/gather_feeds.py
@@ -403,28 +403,6 @@ def process_dataset(
         del feed_overview_dict["end_date"]
         summary.update(feed_overview_dict)
 
-        # Add list of agencies
-        summary["agency_names"] = list(dataset.agency["agency_name"].unique())
-
-        # If there's more than one agency, only include agencies that have bus
-        # service included. We treat this as a separate check because agency_id
-        # is allowed to be NA if there is only one agency in the feed.
-        if len(summary["agency_names"]) > 1:
-            agency_ids = list(dataset.agency["agency_id"].dropna().unique())
-            if agency_ids:
-                # Double check these IDs are represented in bus routes
-                agency_ids_bus = list(
-                    dataset.routes[dataset.routes["route_type"] == GTFS_ROUTE_TYPE_BUS][
-                        "agency_id"
-                    ].unique()
-                )
-                agency_names_bus = (
-                    dataset.agency.set_index("agency_id")
-                    .loc[agency_ids_bus]["agency_name"]
-                    .tolist()
-                )
-                summary["agency_names"] = agency_names_bus
-
         # Compute per-agency metrics (bus trips only, excludes agencies with
         # no bus service)
         if summary.get("includes_bus_trips"):

--- a/scripts/feeds/gather_feeds.py
+++ b/scripts/feeds/gather_feeds.py
@@ -79,6 +79,7 @@ def collect_active_feeds(
 
 def build_feeds_summary(
     active_feeds: list[dict[str, Any]],
+    extractor: GtfsExtractor,
 ) -> pd.DataFrame:
     """Build a summary DataFrame from raw feed records.
 
@@ -86,6 +87,9 @@ def build_feeds_summary(
     ----------
     active_feeds:
         Raw feed records as returned by :func:`collect_active_feeds`.
+    extractor:
+        Authenticated GtfsExtractor instance, used to look up the most recent
+        validated dataset when ``latest_dataset`` has no validation report.
 
     Returns
     -------
@@ -114,6 +118,26 @@ def build_feeds_summary(
         try:
             # Compile the list of states covered by this feed
             states = list(set(loc["subdivision_name"] for loc in f["locations"]))
+            # Determine which dataset to use: prefer the latest validated one.
+            dataset_id = f["latest_dataset"]["id"]
+            if f["latest_dataset"].get("validation_report") is None:
+                datasets = extractor.query_mdb_feed_datasets(f["id"])
+                validated = next(
+                    (d for d in datasets if d.get("validation_report") is not None),
+                    None,
+                )
+                if validated is not None:
+                    dataset_id = validated["id"]
+                    print(
+                        f"Feed {f['id']}: latest dataset unvalidated; "
+                        f"using {dataset_id} instead."
+                    )
+                else:
+                    print(
+                        f"Feed {f['id']}: no validated datasets found. "
+                        "Using latest."
+                    )
+
             feed_info.append(
                 {
                     "id": f["id"],
@@ -121,7 +145,7 @@ def build_feeds_summary(
                     "provider": f["provider"],
                     "status": f["status"],
                     "official": f["official"],
-                    "latest_dataset_id": f["latest_dataset"]["id"],
+                    "latest_dataset_id": dataset_id,
                     "center_latitude": 0.5
                     * (
                         f["bounding_box"]["minimum_latitude"]
@@ -495,7 +519,7 @@ def main() -> None:
         print("Warning: No active feeds found. Exiting.")
         return
 
-    feeds_df = build_feeds_summary(active_feeds)
+    feeds_df = build_feeds_summary(active_feeds, extractor)
 
     all_dataset_summaries: list[dict[str, Any]] = []
     all_agency_metrics: list[dict[str, Any]] = []

--- a/scripts/feeds/gather_feeds.py
+++ b/scripts/feeds/gather_feeds.py
@@ -133,10 +133,7 @@ def build_feeds_summary(
                         f"using {dataset_id} instead."
                     )
                 else:
-                    print(
-                        f"Feed {f['id']}: no validated datasets found. "
-                        "Using latest."
-                    )
+                    print(f"Feed {f['id']}: no validated datasets found. Using latest.")
 
             feed_info.append(
                 {
@@ -263,8 +260,7 @@ def compute_agency_metrics(
             and "service_dist" in dataset.shapes_summary.columns
         ):
             avg_distance = (
-                trip_info
-                .join(dataset.shapes_summary["service_dist"], on="shape_id")
+                trip_info.join(dataset.shapes_summary["service_dist"], on="shape_id")
                 .groupby("agency_id")["service_dist"]
                 .mean()
             )
@@ -408,6 +404,8 @@ def process_dataset(
 
     summary: dict[str, Any] = {
         "id": dataset_id,
+        "feed_id": dataset_response["feed_id"],
+        "downloaded_at": dataset_response["downloaded_at"],
         "has_shapes": has_shapes,
         "has_errors": has_errors,
         "service_date_range_start": dataset_response["service_date_range_start"],

--- a/scripts/feeds/gather_feeds.py
+++ b/scripts/feeds/gather_feeds.py
@@ -175,6 +175,8 @@ def compute_agency_metrics(
         - ``median_trips_per_day``
         - ``avg_trip_duration_minutes``
         - ``avg_trip_distance_miles``
+        - ``center_latitude``
+        - ``center_longitude``
     """
     if bus_trips.empty:
         return []
@@ -182,7 +184,7 @@ def compute_agency_metrics(
     routes = dataset.routes  # indexed by route_id
 
     # Attach agency_id to each bus trip via its route
-    trip_info = bus_trips[["trip_id", "route_id", "service_id"]].copy()
+    trip_info = bus_trips[["trip_id", "route_id", "shape_id", "service_id"]].copy()
     if "agency_id" in routes.columns:
         trip_info = trip_info.join(routes[["agency_id"]], on="route_id")
     else:
@@ -237,14 +239,44 @@ def compute_agency_metrics(
             and "service_dist" in dataset.shapes_summary.columns
         ):
             avg_distance = (
-                trip_info.merge(
-                    bus_trips[["trip_id", "shape_id"]].dropna(subset=["shape_id"]),
-                    on="trip_id",
-                    how="left",
-                )
+                trip_info
                 .join(dataset.shapes_summary["service_dist"], on="shape_id")
                 .groupby("agency_id")["service_dist"]
                 .mean()
+            )
+
+    # --- center_latitude / center_longitude per agency -----------------------
+    agency_location: dict[Any, tuple[float, float] | None] = {}
+    if (
+        "shape_id" in bus_trips.columns
+        and dataset.shapes is not None
+        and not dataset.shapes.empty
+        and "shape_pt_lat" in dataset.shapes.columns
+        and "shape_pt_lon" in dataset.shapes.columns
+    ):
+        shapes_df = dataset.shapes
+        # shape_id may be a column or the index depending on gtfsblocks version
+        shape_id_series = (
+            shapes_df["shape_id"]
+            if "shape_id" in shapes_df.columns
+            else shapes_df.index.to_series()
+        )
+        for agency_key, group in trip_info.groupby("agency_id"):
+            agency_shape_ids = set(group["shape_id"].dropna())
+            if not agency_shape_ids:
+                agency_location[agency_key] = None
+                continue
+            pts = shapes_df[shape_id_series.isin(agency_shape_ids).values]
+            if pts.empty:
+                agency_location[agency_key] = None
+                continue
+            min_lat = float(pts["shape_pt_lat"].min())
+            max_lat = float(pts["shape_pt_lat"].max())
+            min_lon = float(pts["shape_pt_lon"].min())
+            max_lon = float(pts["shape_pt_lon"].max())
+            agency_location[agency_key] = (
+                round(0.5 * (min_lat + max_lat), 6),
+                round(0.5 * (min_lon + max_lon), 6),
             )
 
     # --- agency lookup: placeholder/real key -> (real_id, agency_name) -------
@@ -281,6 +313,7 @@ def compute_agency_metrics(
 
         adur = avg_duration.get(lookup_key)
         adist = avg_distance.get(lookup_key)
+        loc = agency_location.get(lookup_key)
 
         records.append(
             {
@@ -301,6 +334,8 @@ def compute_agency_metrics(
                     if adist is not None and not pd.isna(adist)
                     else None
                 ),
+                "center_latitude": loc[0] if loc is not None else None,
+                "center_longitude": loc[1] if loc is not None else None,
             }
         )
 

--- a/scripts/fta_app_sample_results.py
+++ b/scripts/fta_app_sample_results.py
@@ -81,22 +81,22 @@ if __name__ == "__main__":
     ]
 
     # TODO: aggregate feeds in this script as well
-    # example data built with pixi run -e dev-py311 python scripts/feeds/gather_feeds.py --feed_ids mdb-292 mdb-2432 mdb-2303 --db_root frontend_example
-    db_root = package_root().parents[1] / "frontend_example"
+    # example data built with pixi run -e dev-py311 python scripts/feeds/gather_feeds.py --db_root tmp --feed_ids mdb-292 mdb-1330 mdb-2432 
+    db_root = package_root().parents[1] / "reports" / "results_example_2026_04_22"
     feeds_path = db_root / "feeds.csv"
     datasets_path = db_root / "datasets.csv"
 
     feeds = pd.read_csv(feeds_path)
-    # datasets = pd.read_csv(datasets_path)
+    datasets = pd.read_csv(datasets_path)
 
     feeds_incl = feeds["id"].tolist()
-    datasets_incl = feeds["latest_dataset_id"].tolist()  # assumes no validation errors
+    datasets_incl = datasets["id"].tolist()  # assumes no validation errors
 
     for ix, d_id in enumerate(datasets_incl):
-        # TODO: export routes geojson
         input_directory = db_root / d_id / "gtfs"
         output_directory = db_root / d_id / "results"
 
+        logger.info(f"Starting predictions for {d_id}")
         start_time = time.time()
 
         predictor = GTFSEnergyPredictor(
@@ -117,7 +117,7 @@ if __name__ == "__main__":
             add_hvac=True,
             save_results=True,
         )
-        logger.info(f"Predicted energy for {len(results)} trips in {d_id}")
+        logger.info(f"Finished {len(results)} energy predictions for trips in {d_id}")
 
         # Export routes to GeoJSON
         routes_gdf = build_routes_gdf(predictor.feed)

--- a/scripts/fta_app_sample_results.py
+++ b/scripts/fta_app_sample_results.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     ]
 
     # TODO: aggregate feeds in this script as well
-    # example data built with pixi run -e dev-py311 python scripts/feeds/gather_feeds.py --db_root tmp --feed_ids mdb-292 mdb-1330 mdb-2432 
+    # example data built with pixi run -e dev-py311 python scripts/feeds/gather_feeds.py --db_root tmp --feed_ids mdb-292 mdb-1330 mdb-2432
     db_root = package_root().parents[1] / "reports" / "results_example_2026_04_22"
     feeds_path = db_root / "feeds.csv"
     datasets_path = db_root / "datasets.csv"


### PR DESCRIPTION
* Add agency locations (as center of route shapes' bounding box) to `agencies.csv`
* Only pull datasets that have been validated -- this was causing problems for datasets that get updated every day, so they haven't always been run through the validator yet when fetched