### PR TITLE
Sort shapes by `shape_pt_sequence` before upsampling

### DIFF
--- a/routee/transit/predictor.py
+++ b/routee/transit/predictor.py
@@ -1135,7 +1135,10 @@ class GTFSEnergyPredictor:
         logger.info("Matching shapes to road network...")
 
         # Step 1: Upsample all shapes to ~1 Hz
-        shape_groups = [group for _, group in self.shapes.groupby("shape_id")]
+        shape_groups = [
+            group.sort_values("shape_pt_sequence")
+            for _, group in self.shapes.groupby("shape_id")
+        ]
         with mp.Pool(self.n_processes) as pool:
             upsampled_shapes = pool.map(upsample_shape, shape_groups)
 


### PR DESCRIPTION
A small number of feeds don't have shapes sorted by `shape_pt_sequence` in `shapes.txt`. When this happens, the points within each shape were being connected in a nonsensical order, eventually leading to map matching problems (producing very long shapes and running out of memory). This solves the issue by explicitly sorting by `shape_pt_sequnce` before upsampling and map matching.