### PR TITLE
Update weather scenarios to use a full year of TMY data

### DIFF
--- a/routee/transit/predictor.py
+++ b/routee/transit/predictor.py
@@ -231,6 +231,7 @@ class GTFSEnergyPredictor:
         add_depot_deadhead: bool = False,
         # Energy prediction options
         add_hvac: bool = True,
+        scale_to_year: bool = False,
         save_results: bool = True,
     ) -> pd.DataFrame:
         """
@@ -265,6 +266,12 @@ class GTFSEnergyPredictor:
             (see ``add_mid_block_deadhead``).
         add_hvac : bool, default=True
             Whether to add HVAC energy consumption based on ambient temperature.
+        scale_to_year : bool, default=False
+            When True (and a per-date HVAC run is being performed), project the
+            feed's typical weekday service patterns onto every uncovered date in
+            a full one-year window so the output spans an entire year regardless
+            of feed coverage.  Synthesized rows are flagged with
+            ``trip_is_within_gtfs_scope=False`` in the trip-level output.
         save_results : bool, default=True
             Whether to save results to files.
 
@@ -369,7 +376,7 @@ class GTFSEnergyPredictor:
             self._route_depot_deadhead(depot_metadata)
 
         # Step 6: Predict energy using CompassApp
-        self.predict_energy(add_hvac=add_hvac)
+        self.predict_energy(add_hvac=add_hvac, scale_to_year=scale_to_year)
 
         # Step 7: Save results if requested
         if save_results:
@@ -764,7 +771,6 @@ class GTFSEnergyPredictor:
             how="left",
         )
 
-
         # Accumulate deadhead data for TODS export
         self._deadhead_trips = pd.concat(
             [self._deadhead_trips, deadhead_trips], ignore_index=True
@@ -1009,7 +1015,6 @@ class GTFSEnergyPredictor:
             on="trip_id",
             how="left",
         )
-
 
         # Accumulate deadhead data for TODS export
         self._deadhead_trips = pd.concat(
@@ -1282,6 +1287,7 @@ class GTFSEnergyPredictor:
     def predict_energy(
         self,
         add_hvac: bool = False,
+        scale_to_year: bool = False,
     ) -> dict[str, pd.DataFrame]:
         """
         Predict energy consumption by map matching once, then running
@@ -1461,6 +1467,7 @@ class GTFSEnergyPredictor:
                     self.trips,
                     self.output_dir,
                     service_date=self._service_date,
+                    scale_to_year=scale_to_year,
                 )
                 # Inner join expands trip_results to one row per (trip, calendar date)
                 trip_results = trip_results.merge(hvac_energy, on="trip_id")

--- a/routee/transit/predictor.py
+++ b/routee/transit/predictor.py
@@ -216,19 +216,6 @@ class GTFSEnergyPredictor:
             right_index=True,
         )
 
-        # Add number of times each trip is run
-        sid_counts = (
-            self.feed.get_service_ids_all_dates()
-            .groupby("service_id")["date"]
-            .count()
-            .rename("trip_count")
-        )
-        self.trips = self.trips.merge(
-            sid_counts,
-            left_on="service_id",
-            right_index=True,
-        )
-
     def run(
         self,
         *,
@@ -771,14 +758,6 @@ class GTFSEnergyPredictor:
             how="left",
         )
 
-        # Add trip count column to deadhead trips, let it be the same as the service trips
-        # before or after the deadhead trip
-        deadhead_trips["before_trip"] = deadhead_trips["trip_id"].apply(
-            lambda x: x.split("_to_")[0]
-        )
-        trip_counts = self.trips.set_index("trip_id")["trip_count"].to_dict()
-        deadhead_trips["trip_count"] = deadhead_trips["before_trip"].map(trip_counts)
-        deadhead_trips = deadhead_trips.drop(columns=["before_trip"])
 
         # Accumulate deadhead data for TODS export
         self._deadhead_trips = pd.concat(
@@ -1025,18 +1004,6 @@ class GTFSEnergyPredictor:
             how="left",
         )
 
-        # Add trip count column to deadhead trips, let it be the same as the service trips
-        # before or after the deadhead trip
-        deadhead_trips["before_or_after_trip"] = deadhead_trips["trip_id"].apply(
-            lambda x: (
-                x.split("depot_to_")[1] if "depot_to_" in x else x.split("_to_depot")[0]
-            )
-        )
-        trip_counts = self.trips.set_index("trip_id")["trip_count"].to_dict()
-        deadhead_trips["trip_count"] = deadhead_trips["before_or_after_trip"].map(
-            trip_counts
-        )
-        deadhead_trips = deadhead_trips.drop(columns=["before_or_after_trip"])
 
         # Accumulate deadhead data for TODS export
         self._deadhead_trips = pd.concat(
@@ -1484,12 +1451,14 @@ class GTFSEnergyPredictor:
             if add_hvac:
                 logger.info("Adding HVAC energy impacts...")
                 hvac_energy = add_HVAC_energy(self.feed, self.trips, self.output_dir)
-                trip_results = trip_results.merge(hvac_energy, on="trip_id", how="left")
+                # Inner join expands trip_results to one row per (trip, calendar date)
+                trip_results = trip_results.merge(hvac_energy, on="trip_id")
                 # Add HVAC energy to powertrain energy for electric vehicles
                 kwh_mask = trip_results["energy_unit"] == "kWh"
                 trip_results.loc[kwh_mask, "energy_used"] += trip_results.loc[
                     kwh_mask, "hvac_energy_kWh"
                 ]
+                trip_results = trip_results.merge(self.trips, on="trip_id")
             else:
                 trip_results = trip_results.merge(self.trips, on="trip_id")
 

--- a/routee/transit/predictor.py
+++ b/routee/transit/predictor.py
@@ -1469,8 +1469,7 @@ class GTFSEnergyPredictor:
                     service_date=self._service_date,
                     scale_to_year=scale_to_year,
                 )
-                # Inner join expands trip_results to one row per (trip, calendar date)
-                trip_results = trip_results.merge(hvac_energy, on="trip_id")
+                trip_results = trip_results.merge(hvac_energy, on="trip_id", how="left")
                 # Add HVAC energy to powertrain energy for electric vehicles
                 kwh_mask = trip_results["energy_unit"] == "kWh"
                 trip_results.loc[kwh_mask, "energy_used"] += trip_results.loc[

--- a/routee/transit/predictor.py
+++ b/routee/transit/predictor.py
@@ -172,6 +172,10 @@ class GTFSEnergyPredictor:
         # from its ``date`` argument; used to stamp deadhead routing queries for
         # time-of-day traversal models. None when no date filter is applied.
         self._service_weekday: str | None = None
+        # The specific service date used to filter trips (as a Timestamp), or None
+        # when no date filter was applied.  Passed to add_HVAC_energy() so that
+        # single-date runs only model HVAC for that one day.
+        self._service_date: pd.Timestamp | None = None
         self.energy_predictions: dict[str, pd.DataFrame] = {}
         self._bbox: tuple[float, float, float, float] | None = None
 
@@ -318,8 +322,10 @@ class GTFSEnergyPredictor:
             self._service_weekday = (
                 pd.Timestamp(date.replace("/", "-")).day_name().lower()
             )
+            self._service_date = pd.Timestamp(date.replace("/", "-"))
         else:
             self._service_weekday = None
+            self._service_date = None
 
         if date is not None or routes is not None:
             self.filter_trips(
@@ -1450,7 +1456,12 @@ class GTFSEnergyPredictor:
             # Optionally add HVAC to trip-level results
             if add_hvac:
                 logger.info("Adding HVAC energy impacts...")
-                hvac_energy = add_HVAC_energy(self.feed, self.trips, self.output_dir)
+                hvac_energy = add_HVAC_energy(
+                    self.feed,
+                    self.trips,
+                    self.output_dir,
+                    service_date=self._service_date,
+                )
                 # Inner join expands trip_results to one row per (trip, calendar date)
                 trip_results = trip_results.merge(hvac_energy, on="trip_id")
                 # Add HVAC energy to powertrain energy for electric vehicles

--- a/routee/transit/predictor.py
+++ b/routee/transit/predictor.py
@@ -267,10 +267,10 @@ class GTFSEnergyPredictor:
         add_hvac : bool, default=True
             Whether to add HVAC energy consumption based on ambient temperature.
         scale_to_year : bool, default=False
-            When True (and a per-date HVAC run is being performed), project the
-            feed's typical weekday service patterns onto every uncovered date in
-            a full one-year window so the output spans an entire year regardless
-            of feed coverage.  Synthesized rows are flagged with
+            When True (and no `date` filter is applied), project the feed's typical
+            weekday service patterns onto every uncovered date in a full one-year
+            window so the output spans an entire year regardless of feed coverage.
+            Synthesized rows are flagged with
             ``trip_is_within_gtfs_scope=False`` in the trip-level output.
         save_results : bool, default=True
             Whether to save results to files.

--- a/routee/transit/thermal_energy.py
+++ b/routee/transit/thermal_energy.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import cast
 
 import boto3
 import geopandas as gpd
@@ -35,7 +36,7 @@ def download_tmy_files(county_ids: list[str], tmy_dir: Path) -> None:
     modeling and system design studies.
 
     This function downloads TMY files for all the supplied county IDs and saves them to
-    TMY_DIR. It returns None.
+    `tmy_dir`. It returns None.
 
     Parameters
     ----------
@@ -149,61 +150,57 @@ def compute_HVAC_energy(
     return np.array(energies)
 
 
-def get_hourly_temperature(
+def load_tmy_power_by_day(
     county_id: str,
-    scenario: str,
     tmy_dir: Path,
+    df_temp_energy: pd.DataFrame,
 ) -> pd.DataFrame:
+    """
+    Load the full TMY temperature profile for a county and convert to power values.
+
+    Parameters
+    ----------
+    county_id : str
+        US Census county identifier.
+    tmy_dir : Path
+        Directory containing downloaded TMY CSV files.
+    df_temp_energy : pd.DataFrame
+        Lookup table mapping temperature (Temp_C) to power (Power) in kW,
+        as returned by load_thermal_lookup_table().
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns: month, day_of_month, hour, Power.
+        One row per hour of the synthetic TMY year (8760 rows).
+    """
     local_file = tmy_dir / f"{county_id}.csv"
     tmy_df = pd.read_csv(local_file, parse_dates=["date_time"])[
         ["date_time", "Dry Bulb Temperature [°C]"]
     ]
-    tmy_df["day_of_year"] = tmy_df["date_time"].dt.day_of_year
-    mean_temp_by_day = (
-        tmy_df.groupby("day_of_year")
-        .agg(avg_temp_C=("Dry Bulb Temperature [°C]", "mean"))
-        .reset_index()
+    tmy_df["month"] = tmy_df["date_time"].dt.month
+    tmy_df["day_of_month"] = tmy_df["date_time"].dt.day
+    tmy_df["hour"] = tmy_df["date_time"].dt.hour
+    tmy_df["Dry Bulb Temperature [°C]"] = tmy_df["Dry Bulb Temperature [°C]"].round(1)
+    tmy_df = tmy_df.merge(
+        df_temp_energy,
+        left_on="Dry Bulb Temperature [°C]",
+        right_on="Temp_C",
+        how="left",
     )
-
-    if scenario == "winter":
-        # Find the days with the hottest and coldest average temperature
-        cold_day: int = mean_temp_by_day[
-            mean_temp_by_day.avg_temp_C == mean_temp_by_day.avg_temp_C.min()
-        ]["day_of_year"].iloc[0]
-
-        # Grab the hourly profiles for the coldest and hottest days
-        df_out = tmy_df[tmy_df["day_of_year"] == cold_day].copy()
-
-    elif scenario == "summer":
-        hot_day: int = mean_temp_by_day[
-            mean_temp_by_day.avg_temp_C == mean_temp_by_day.avg_temp_C.max()
-        ]["day_of_year"].iloc[0]
-        df_out = tmy_df[tmy_df["day_of_year"] == hot_day].copy()
-
-    elif scenario == "median":
-        median_day: int = mean_temp_by_day.iloc[
-            (mean_temp_by_day["avg_temp_C"] - mean_temp_by_day["avg_temp_C"].median())
-            .abs()
-            .argsort()[:1]
-        ]["day_of_year"].iloc[0]
-
-        df_out = tmy_df[tmy_df["day_of_year"] == median_day].copy()
-        df_out["Dry Bulb Temperature [°C]"] = df_out["Dry Bulb Temperature [°C]"].round(
-            1
-        )
-
-    else:
-        raise ValueError(f"Unknown scenario: {scenario}")
-
-    df_out["hour"] = df_out["date_time"].dt.hour
-    return df_out
+    return tmy_df[["month", "day_of_month", "hour", "Power"]]
 
 
 def add_HVAC_energy(
-    feed: Feed, trips_df: pd.DataFrame, output_dir: Path | None = None
+    feed: Feed, trips_df: pd.DataFrame, output_dir: Path | None = None, max_days: int = 365
 ) -> pd.DataFrame:
     """
-    Add HVAC energy consumption.
+    Add HVAC energy consumption for each calendar day covered by the feed.
+
+    Uses Typical Meteorological Year (TMY) temperature data to compute hourly
+    HVAC+BTMS power demand for every day the feed is active (up to ``max_days``
+    days).  Each trip is replicated once per calendar day on which it runs, with
+    ``hvac_energy_kWh`` reflecting the temperature conditions for that specific day.
 
     Parameters
     ----------
@@ -211,16 +208,20 @@ def add_HVAC_energy(
         GTFS feed object containing blocks DataFrame.
     trips_df : pd.DataFrame
         Trips on selected date and route, including deadhead trips.
+        Must contain ``trip_id`` and ``service_id`` columns.
     output_dir : Path or None
         Directory used to store downloaded TMY weather files (in a ``TMY/``
         subdirectory). If None, defaults to ``~/cache/routee-transit/TMY``.
+    max_days : int, default=365
+        Maximum number of calendar days to model.  The earliest ``max_days``
+        service dates in the feed are used; later dates are ignored.
 
     Returns
     -------
     pd.DataFrame
-        Updated trip-level energy prediction DataFrame with HVAC energy
-        consumption per trip for each weather scenario
-        (``summer``, ``winter``, ``median``).
+        DataFrame with columns ``trip_id``, ``date``, ``scenario``, and
+        ``hvac_energy_kWh``.  One row per (trip, calendar day) combination.
+        ``scenario`` is always ``"TMY"``.
     """
     if output_dir is not None:
         tmy_dir = output_dir / "TMY"
@@ -281,54 +282,74 @@ def add_HVAC_energy(
 
     df_temp_energy = load_thermal_lookup_table()
 
-    # Get the power tables for different weather scenarios
-    thermal_dfs = []
-    for county_id in county_ids:
-        for scenario in ["summer", "winter", "median"]:
-            hourly_temp_df = get_hourly_temperature(county_id, scenario, tmy_dir)
-            hourly_temp_df["Dry Bulb Temperature [°C]"] = hourly_temp_df[
-                "Dry Bulb Temperature [°C]"
-            ].round(1)
-            hourly_temp_df = hourly_temp_df.merge(
-                df_temp_energy,
-                left_on="Dry Bulb Temperature [°C]",
-                right_on="Temp_C",
-                how="left",
-            )
-            hourly_temp_df["scenario"] = scenario
-            hourly_temp_df["county"] = county_id
-            thermal_dfs.append(hourly_temp_df)
-
-    thermal_power_vals = (
-        pd.concat(thermal_dfs).groupby(["scenario", "hour"])["Power"].mean()
+    # Build a (month, day_of_month, hour) → power table averaged across all counties
+    # TODO: use allow shape-dependent TMY data choice
+    county_power_dfs = [
+        load_tmy_power_by_day(county_id, tmy_dir, df_temp_energy)
+        for county_id in county_ids
+    ]
+    avg_power = (
+        pd.concat(county_power_dfs)
+        .groupby(["month", "day_of_month", "hour"])["Power"]
+        .mean()
+        .reset_index()
     )
 
-    # Last calculate the trip HVAC energy
-    # Get the start and end time for each trip
+    # Build lookup: (month, day_of_month) → np.array[24] of hourly power values
+    power_lookup: dict[tuple[int, int], np.ndarray] = {}
+    for key, grp in avg_power.groupby(["month", "day_of_month"]):
+        month_key, day_key = cast(tuple[int, int], key)
+        power_lookup[(month_key, day_key)] = (
+            grp.sort_values("hour")["Power"].to_numpy()
+        )
+
+    # Get all (date, service_id) pairs covered by the feed, capped to max_days
+    all_dates_df = feed.get_service_ids_all_dates()
+    unique_dates = sorted(all_dates_df["date"].unique())[:max_days]
+    date_service_df = all_dates_df[all_dates_df["date"].isin(unique_dates)][
+        ["date", "service_id"]
+    ].drop_duplicates()
+
+    # Join dates to trips via service_id
+    trips_slim = trips_df[["trip_id", "service_id"]].drop_duplicates()
+    date_trips = date_service_df.merge(trips_slim, on="service_id")
+
+    # Load trip start/end fractional hours from stop_times
     df_stop_times = feed.stop_times[
         feed.stop_times["trip_id"].isin(trips_df["trip_id"].unique())
     ].copy()
-    df_trip_time = (
+    trip_hours = (
         df_stop_times.groupby("trip_id")
         .agg(start_time=("arrival_time", "min"), end_time=("arrival_time", "max"))
         .reset_index()
     )
-    start_hours = df_trip_time["start_time"].dt.total_seconds() / 3600
-    end_hours = df_trip_time["end_time"].dt.total_seconds() / 3600
+    trip_hours["start_hour"] = trip_hours["start_time"].dt.total_seconds() / 3600
+    trip_hours["end_hour"] = trip_hours["end_time"].dt.total_seconds() / 3600
 
-    hvac_df_list = []
-    for scen, subdf in thermal_power_vals.reset_index().groupby("scenario"):
-        scenario_trips = trips_df.copy()
-        scenario_trips["scenario"] = scen
-        scenario_trips["hvac_energy_kWh"] = compute_HVAC_energy(
-            start_hours, end_hours, subdf["Power"].to_numpy()
-        )
-        hvac_df_list.append(scenario_trips)
-
-    all_predictions = pd.concat(hvac_df_list).reset_index(drop=True)
-    trips_df_out = trips_df.merge(
-        all_predictions[["trip_id", "scenario", "hvac_energy_kWh"]],
-        on="trip_id",
-        how="inner",
+    date_trips = date_trips.merge(
+        trip_hours[["trip_id", "start_hour", "end_hour"]], on="trip_id"
     )
-    return trips_df_out
+
+    # Add (month, day_of_month) columns for power lookup
+    date_trips["month"] = date_trips["date"].dt.month
+    date_trips["day_of_month"] = date_trips["date"].dt.day
+    # Feb 29 → Feb 28 (TMY is a non-leap synthetic year)
+    feb29_mask = (date_trips["month"] == 2) & (date_trips["day_of_month"] == 29)
+    date_trips.loc[feb29_mask, "day_of_month"] = 28
+
+    # Compute HVAC energy for each unique (month, day_of_month) power profile
+    result_parts: list[pd.DataFrame] = []
+    for key, grp in date_trips.groupby(["month", "day_of_month"], sort=False):
+        month_key, day_key = cast(tuple[int, int], key)
+        power_array = power_lookup[(month_key, day_key)]
+        grp_reset = grp.reset_index(drop=True)
+        hvac_vals = compute_HVAC_energy(
+            grp_reset["start_hour"], grp_reset["end_hour"], power_array
+        )
+        part = grp_reset[["trip_id", "date"]].copy()
+        part["hvac_energy_kWh"] = hvac_vals
+        result_parts.append(part)
+
+    result = pd.concat(result_parts, ignore_index=True)
+    result["scenario"] = "TMY"
+    return result[["trip_id", "date", "scenario", "hvac_energy_kWh"]]

--- a/routee/transit/thermal_energy.py
+++ b/routee/transit/thermal_energy.py
@@ -192,7 +192,11 @@ def load_tmy_power_by_day(
 
 
 def add_HVAC_energy(
-    feed: Feed, trips_df: pd.DataFrame, output_dir: Path | None = None, max_days: int = 365
+    feed: Feed,
+    trips_df: pd.DataFrame,
+    output_dir: Path | None = None,
+    max_days: int = 365,
+    service_date: pd.Timestamp | None = None,
 ) -> pd.DataFrame:
     """
     Add HVAC energy consumption for each calendar day covered by the feed.
@@ -214,7 +218,13 @@ def add_HVAC_energy(
         subdirectory). If None, defaults to ``~/cache/routee-transit/TMY``.
     max_days : int, default=365
         Maximum number of calendar days to model.  The earliest ``max_days``
-        service dates in the feed are used; later dates are ignored.
+        service dates in the feed are used; later dates are ignored.  Ignored
+        when ``service_date`` is provided.
+    service_date : pd.Timestamp or None
+        When set, only this single calendar date is modeled for HVAC.  This
+        should be supplied when the predictor was run with a specific ``date``
+        filter so that the output contains exactly one row per trip rather than
+        one row per (trip, day-in-feed).
 
     Returns
     -------
@@ -299,16 +309,21 @@ def add_HVAC_energy(
     power_lookup: dict[tuple[int, int], np.ndarray] = {}
     for key, grp in avg_power.groupby(["month", "day_of_month"]):
         month_key, day_key = cast(tuple[int, int], key)
-        power_lookup[(month_key, day_key)] = (
-            grp.sort_values("hour")["Power"].to_numpy()
-        )
+        power_lookup[(month_key, day_key)] = grp.sort_values("hour")["Power"].to_numpy()
 
-    # Get all (date, service_id) pairs covered by the feed, capped to max_days
+    # Get all (date, service_id) pairs covered by the feed, capped to max_days.
+    # If a specific service_date was supplied (single-date run), restrict to that
+    # date only — do not re-expand to every day the service_id runs.
     all_dates_df = feed.get_service_ids_all_dates()
-    unique_dates = sorted(all_dates_df["date"].unique())[:max_days]
-    date_service_df = all_dates_df[all_dates_df["date"].isin(unique_dates)][
-        ["date", "service_id"]
-    ].drop_duplicates()
+    if service_date is not None:
+        date_service_df = all_dates_df[all_dates_df["date"] == service_date][
+            ["date", "service_id"]
+        ].drop_duplicates()
+    else:
+        unique_dates = sorted(all_dates_df["date"].unique())[:max_days]
+        date_service_df = all_dates_df[all_dates_df["date"].isin(unique_dates)][
+            ["date", "service_id"]
+        ].drop_duplicates()
 
     # Join dates to trips via service_id
     trips_slim = trips_df[["trip_id", "service_id"]].drop_duplicates()

--- a/routee/transit/thermal_energy.py
+++ b/routee/transit/thermal_energy.py
@@ -191,12 +191,62 @@ def load_tmy_power_by_day(
     return tmy_df[["month", "day_of_month", "hour", "Power"]]
 
 
+def _densest_window(
+    sorted_dates: list[pd.Timestamp], max_days: int
+) -> tuple[pd.Timestamp, pd.Timestamp] | None:
+    """
+    Return the (start, end) of the ``max_days``-wide window containing the most
+    service dates.  Robust to feeds with sparse outliers far in the past or future.
+    Returns None if ``sorted_dates`` is empty.
+    """
+    if not sorted_dates:
+        return None
+    best_start = sorted_dates[0]
+    best_count = 0
+    j = 0
+    for i, start in enumerate(sorted_dates):
+        window_end = start + pd.Timedelta(days=max_days - 1)
+        while j < len(sorted_dates) and sorted_dates[j] <= window_end:
+            j += 1
+        count = j - i
+        if count > best_count:
+            best_count = count
+            best_start = start
+    return best_start, best_start + pd.Timedelta(days=max_days - 1)
+
+
+def _select_full_year_window(
+    sorted_dates: list[pd.Timestamp], max_days: int
+) -> tuple[pd.Timestamp, pd.Timestamp]:
+    """
+    Pick a full-year window for scale_to_year mode.
+
+    Snaps to a calendar year (Jan 1 - Dec 31) when the dense block of service
+    dates falls within a single year; otherwise centers a ``max_days``-wide
+    window on the midpoint of the dense block.
+    """
+    dense = _densest_window(sorted_dates, max_days)
+    assert dense is not None  # caller guarantees non-empty
+    dense_start, dense_end = dense
+    dense_dates = [d for d in sorted_dates if dense_start <= d <= dense_end]
+    first, last = dense_dates[0], dense_dates[-1]
+    if first.year == last.year:
+        year = first.year
+        return pd.Timestamp(year=year, month=1, day=1), pd.Timestamp(
+            year=year, month=12, day=31
+        )
+    midpoint = first + (last - first) / 2
+    half = pd.Timedelta(days=(max_days - 1) // 2)
+    return midpoint - half, midpoint - half + pd.Timedelta(days=max_days - 1)
+
+
 def add_HVAC_energy(
     feed: Feed,
     trips_df: pd.DataFrame,
     output_dir: Path | None = None,
     max_days: int = 365,
     service_date: pd.Timestamp | None = None,
+    scale_to_year: bool = False,
 ) -> pd.DataFrame:
     """
     Add HVAC energy consumption for each calendar day covered by the feed.
@@ -226,13 +276,20 @@ def add_HVAC_energy(
         should be supplied when the predictor was run with a specific ``date``
         filter so that the output contains exactly one row per trip rather than
         one row per (trip, day-in-feed).
+    scale_to_year : bool, default=False
+        When True, project the feed's typical weekday service patterns onto every
+        uncovered date in a full ``max_days``-wide window so the output spans an
+        entire year regardless of feed coverage.  Synthesized dates are flagged
+        with ``trip_is_within_gtfs_scope=False``.
 
     Returns
     -------
     pd.DataFrame
-        DataFrame with columns ``trip_id``, ``date``, ``scenario``, and
-        ``hvac_energy_kWh``.  One row per (trip, calendar day) combination.
-        ``scenario`` is always ``"TMY"``.
+        DataFrame with columns ``trip_id``, ``date``, ``scenario``,
+        ``hvac_energy_kWh``, and ``trip_is_within_gtfs_scope``.  One row per
+        (trip, calendar day) combination.  ``scenario`` is always ``"TMY"``.
+        ``trip_is_within_gtfs_scope`` is True when the date is part of the
+        feed's actual calendar, False when synthesized via ``scale_to_year``.
     """
     if output_dir is not None:
         tmy_dir = output_dir / "TMY"
@@ -320,31 +377,51 @@ def add_HVAC_energy(
         date_service_df = all_dates_df[all_dates_df["date"] == service_date][
             ["date", "service_id"]
         ].drop_duplicates()
+        date_service_df["trip_is_within_gtfs_scope"] = True
     else:
-        # Find the max_days-calendar-day window containing the most service dates.
-        # Using a sliding window over the sorted date list makes this robust to
-        # feeds with sparse outlier dates far in the past or future (e.g. Frederick
-        # MD), since those lone dates can never anchor a dense window.
         all_unique = sorted(all_dates_df["date"].unique())
-        if all_unique:
-            best_start = all_unique[0]
-            best_count = 0
-            j = 0
-            for i, start in enumerate(all_unique):
-                window_end = start + pd.Timedelta(days=max_days - 1)
-                while j < len(all_unique) and all_unique[j] <= window_end:
-                    j += 1
-                count = j - i
-                if count > best_count:
-                    best_count = count
-                    best_start = start
-            best_end = best_start + pd.Timedelta(days=max_days - 1)
-            in_window = [d for d in all_unique if best_start <= d <= best_end]
+        if scale_to_year and all_unique:
+            window_start, window_end = _select_full_year_window(all_unique, max_days)
         else:
-            in_window = []
-        date_service_df = all_dates_df[all_dates_df["date"].isin(in_window)][
-            ["date", "service_id"]
+            dense = _densest_window(all_unique, max_days)
+            if dense is None:
+                window_start = window_end = pd.Timestamp("1970-01-01")
+            else:
+                window_start, window_end = dense
+
+        in_window_mask = (all_dates_df["date"] >= window_start) & (
+            all_dates_df["date"] <= window_end
+        )
+        date_service_df = all_dates_df.loc[
+            in_window_mask, ["date", "service_id"]
         ].drop_duplicates()
+        date_service_df["trip_is_within_gtfs_scope"] = True
+
+        if scale_to_year and all_unique:
+            # Project the feed's typical weekday service patterns onto uncovered
+            # dates within the full-year window.  Weekdays absent from the
+            # typical-service map (e.g. Tuesday in an M/W/F-only feed) get no
+            # projected rows, preserving the feed's real day-of-week service shape.
+            typical = feed.get_typical_service_by_weekday()
+            weekday_to_sids: dict[str, list[str]] = {
+                weekday: list(row["service_id"]) for weekday, row in typical.iterrows()
+            }
+            covered_dates: set[pd.Timestamp] = set(date_service_df["date"].unique())
+            all_window_dates = pd.date_range(window_start, window_end, freq="D")
+            uncovered_dates = [d for d in all_window_dates if d not in covered_dates]
+            projected_rows = []
+            for d in uncovered_dates:
+                weekday_name = d.day_name().lower()
+                for sid in weekday_to_sids.get(weekday_name, []):
+                    projected_rows.append((d, sid, False))
+            if projected_rows:
+                projected_df = pd.DataFrame(
+                    projected_rows,
+                    columns=["date", "service_id", "trip_is_within_gtfs_scope"],
+                )
+                date_service_df = pd.concat(
+                    [date_service_df, projected_df], ignore_index=True
+                )
 
     # Join dates to trips via service_id
     trips_slim = trips_df[["trip_id", "service_id"]].drop_duplicates()
@@ -382,10 +459,17 @@ def add_HVAC_energy(
         hvac_vals = compute_HVAC_energy(
             grp_reset["start_hour"], grp_reset["end_hour"], power_array
         )
-        part = grp_reset[["trip_id", "date"]].copy()
+        part = grp_reset[["trip_id", "date", "trip_is_within_gtfs_scope"]].copy()
         part["hvac_energy_kWh"] = hvac_vals
         result_parts.append(part)
 
-    result = pd.concat(result_parts, ignore_index=True)
+    if result_parts:
+        result = pd.concat(result_parts, ignore_index=True)
+    else:
+        result = pd.DataFrame(
+            columns=["trip_id", "date", "trip_is_within_gtfs_scope", "hvac_energy_kWh"]
+        )
     result["scenario"] = "TMY"
-    return result[["trip_id", "date", "scenario", "hvac_energy_kWh"]]
+    return result[
+        ["trip_id", "date", "scenario", "hvac_energy_kWh", "trip_is_within_gtfs_scope"]
+    ]

--- a/routee/transit/thermal_energy.py
+++ b/routee/transit/thermal_energy.py
@@ -379,7 +379,8 @@ def add_HVAC_energy(
         ].drop_duplicates()
         date_service_df["trip_is_within_gtfs_scope"] = True
     else:
-        all_unique = sorted(all_dates_df["date"].unique())
+        all_unique = pd.to_datetime(all_dates_df["date"].dropna().unique()).to_list()
+        all_unique.sort()
         if scale_to_year and all_unique:
             window_start, window_end = _select_full_year_window(all_unique, max_days)
         else:
@@ -406,7 +407,9 @@ def add_HVAC_energy(
             weekday_to_sids: dict[str, list[str]] = {
                 weekday: list(row["service_id"]) for weekday, row in typical.iterrows()
             }
-            covered_dates: set[pd.Timestamp] = set(date_service_df["date"].unique())
+            covered_dates: set[pd.Timestamp] = set(
+                pd.to_datetime(date_service_df["date"]).to_list()
+            )
             all_window_dates = pd.date_range(window_start, window_end, freq="D")
             uncovered_dates = [d for d in all_window_dates if d not in covered_dates]
             projected_rows = []
@@ -424,6 +427,10 @@ def add_HVAC_energy(
                 )
 
     # Join dates to trips via service_id
+    required_cols = {"trip_id", "service_id"}
+    missing = required_cols.difference(trips_df.columns)
+    if missing:
+        raise ValueError(f"trips_df is missing required columns: {sorted(missing)}")
     trips_slim = trips_df[["trip_id", "service_id"]].drop_duplicates()
     date_trips = date_service_df.merge(trips_slim, on="service_id")
 

--- a/routee/transit/thermal_energy.py
+++ b/routee/transit/thermal_energy.py
@@ -364,7 +364,7 @@ def add_HVAC_energy(
     )
 
     # Build lookup: (month, day_of_month) → np.array[24] of hourly power values
-    power_lookup: dict[tuple[int, int], np.ndarray] = {}
+    power_lookup = {}
     for key, grp in avg_power.groupby(["month", "day_of_month"]):
         month_key, day_key = cast(tuple[int, int], key)
         power_lookup[(month_key, day_key)] = grp.sort_values("hour")["Power"].to_numpy()

--- a/routee/transit/thermal_energy.py
+++ b/routee/transit/thermal_energy.py
@@ -217,9 +217,10 @@ def add_HVAC_energy(
         Directory used to store downloaded TMY weather files (in a ``TMY/``
         subdirectory). If None, defaults to ``~/cache/routee-transit/TMY``.
     max_days : int, default=365
-        Maximum number of calendar days to model.  The earliest ``max_days``
-        service dates in the feed are used; later dates are ignored.  Ignored
-        when ``service_date`` is provided.
+        Width in calendar days of the window to model.  The algorithm selects the
+        ``max_days``-wide window that contains the greatest number of service dates,
+        so that it is robust to feeds with sparse outlier dates far in the past or
+        future.  Ignored when ``service_date`` is provided.
     service_date : pd.Timestamp or None
         When set, only this single calendar date is modeled for HVAC.  This
         should be supplied when the predictor was run with a specific ``date``
@@ -320,8 +321,28 @@ def add_HVAC_energy(
             ["date", "service_id"]
         ].drop_duplicates()
     else:
-        unique_dates = sorted(all_dates_df["date"].unique())[:max_days]
-        date_service_df = all_dates_df[all_dates_df["date"].isin(unique_dates)][
+        # Find the max_days-calendar-day window containing the most service dates.
+        # Using a sliding window over the sorted date list makes this robust to
+        # feeds with sparse outlier dates far in the past or future (e.g. Frederick
+        # MD), since those lone dates can never anchor a dense window.
+        all_unique = sorted(all_dates_df["date"].unique())
+        if all_unique:
+            best_start = all_unique[0]
+            best_count = 0
+            j = 0
+            for i, start in enumerate(all_unique):
+                window_end = start + pd.Timedelta(days=max_days - 1)
+                while j < len(all_unique) and all_unique[j] <= window_end:
+                    j += 1
+                count = j - i
+                if count > best_count:
+                    best_count = count
+                    best_start = start
+            best_end = best_start + pd.Timedelta(days=max_days - 1)
+            in_window = [d for d in all_unique if best_start <= d <= best_end]
+        else:
+            in_window = []
+        date_service_df = all_dates_df[all_dates_df["date"].isin(in_window)][
             ["date", "service_id"]
         ].drop_duplicates()
 

--- a/routee/transit/thermal_energy.py
+++ b/routee/transit/thermal_energy.py
@@ -379,7 +379,7 @@ def add_HVAC_energy(
         ].drop_duplicates()
         date_service_df["trip_is_within_gtfs_scope"] = True
     else:
-        all_unique = pd.to_datetime(all_dates_df["date"].dropna().unique()).to_list()
+        all_unique = pd.to_datetime(all_dates_df["date"].dropna().unique()).tolist()
         all_unique.sort()
         if scale_to_year and all_unique:
             window_start, window_end = _select_full_year_window(all_unique, max_days)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -80,9 +80,7 @@ def test_e2e_uta() -> None:
     if "scenario" in trip_results.columns:
         tmy_results = trip_results[trip_results["scenario"] == "TMY"]
         assert not tmy_results.empty, "TMY scenario results should not be empty"
-        assert (tmy_results["energy_used"] > 0).all(), (
-            "TMY energy should be positive"
-        )
+        assert (tmy_results["energy_used"] > 0).all(), "TMY energy should be positive"
 
     # Link-level predictions
     link_results = predictor.get_link_predictions()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -78,17 +78,10 @@ def test_e2e_uta() -> None:
 
     # Verify HVAC energy calculation if present
     if "scenario" in trip_results.columns:
-        winter_results = trip_results[trip_results["scenario"] == "winter"]
-        summer_results = trip_results[trip_results["scenario"] == "summer"]
-
-        assert not winter_results.empty, "Winter scenario results should not be empty"
-        assert not summer_results.empty, "Summer scenario results should not be empty"
-
-        assert (winter_results["energy_used"] > 0).all(), (
-            "Winter energy should be positive"
-        )
-        assert (summer_results["energy_used"] > 0).all(), (
-            "Summer energy should be positive"
+        tmy_results = trip_results[trip_results["scenario"] == "TMY"]
+        assert not tmy_results.empty, "TMY scenario results should not be empty"
+        assert (tmy_results["energy_used"] > 0).all(), (
+            "TMY energy should be positive"
         )
 
     # Link-level predictions

--- a/tests/test_thermal_energy.py
+++ b/tests/test_thermal_energy.py
@@ -52,7 +52,15 @@ class TestThermalEnergy(unittest.TestCase):
                 "stop_id": ["S1", "S1"],
             }
         )
-        trips_df = pd.DataFrame({"trip_id": ["T1"]})
+        # Two service dates, both running service_id "S1" → trip "T1"
+        mock_feed.get_service_ids_all_dates.return_value = pd.DataFrame(
+            {
+                "date": pd.to_datetime(["2023-01-15", "2023-07-15"]),
+                "service_id": ["S1", "S1"],
+                "weekday": ["sunday", "saturday"],
+            }
+        )
+        trips_df = pd.DataFrame({"trip_id": ["T1"], "service_id": ["S1"]})
         mock_county_gdf = gpd.GeoDataFrame(
             {
                 "county_id": ["G0800130"],
@@ -62,25 +70,29 @@ class TestThermalEnergy(unittest.TestCase):
             },
             crs="EPSG:4269",
         )
-        mock_hourly_temp = pd.DataFrame(
-            {"hour": list(range(24)), "Dry Bulb Temperature [°C]": [20.0] * 24}
-        )
-        return mock_feed, trips_df, mock_county_gdf, mock_hourly_temp
+        # Synthetic per-day power table: one row per (month, day_of_month, hour)
+        # covering just the two dates used in the test (Jan 15, Jul 15)
+        rows = []
+        for month, day in [(1, 15), (7, 15)]:
+            for hour in range(24):
+                rows.append({"month": month, "day_of_month": day, "hour": hour, "Power": 5.0})
+        mock_power_by_day = pd.DataFrame(rows)
+        return mock_feed, trips_df, mock_county_gdf, mock_power_by_day
 
     @patch("routee.transit.thermal_energy.fetch_counties_gdf")
     @patch("routee.transit.thermal_energy.download_tmy_files")
-    @patch("routee.transit.thermal_energy.get_hourly_temperature")
+    @patch("routee.transit.thermal_energy.load_tmy_power_by_day")
     def test_add_HVAC_energy(
         self,
-        mock_get_hourly: MagicMock,
+        mock_load_power: MagicMock,
         mock_download: MagicMock,
         mock_fetch_counties: MagicMock,
     ) -> None:
-        mock_feed, trips_df, mock_county_gdf, mock_hourly_temp = (
+        mock_feed, trips_df, mock_county_gdf, mock_power_by_day = (
             self._make_mock_feed_and_trips()
         )
         mock_fetch_counties.return_value = mock_county_gdf
-        mock_get_hourly.return_value = mock_hourly_temp
+        mock_load_power.return_value = mock_power_by_day
 
         # use a temp directory for output
         output_directory = Path(tempfile.mkdtemp())
@@ -89,31 +101,36 @@ class TestThermalEnergy(unittest.TestCase):
 
         self.assertIn("hvac_energy_kWh", result.columns)
         self.assertIn("scenario", result.columns)
-        # Should have results for 3 scenarios: summer, winter, median
-        self.assertEqual(len(result), 3)
+        self.assertIn("date", result.columns)
+        # scenario is always "TMY"
+        self.assertTrue((result["scenario"] == "TMY").all())
+        # 2 dates × 1 trip = 2 rows
+        self.assertEqual(len(result), 2)
 
     @patch("routee.transit.thermal_energy.fetch_counties_gdf")
     @patch("routee.transit.thermal_energy.download_tmy_files")
-    @patch("routee.transit.thermal_energy.get_hourly_temperature")
+    @patch("routee.transit.thermal_energy.load_tmy_power_by_day")
     def test_add_HVAC_energy_no_output_dir(
         self,
-        mock_get_hourly: MagicMock,
+        mock_load_power: MagicMock,
         mock_download: MagicMock,
         mock_fetch_counties: MagicMock,
     ) -> None:
         """add_HVAC_energy should work without output_dir using a default cache path."""
-        mock_feed, trips_df, mock_county_gdf, mock_hourly_temp = (
+        mock_feed, trips_df, mock_county_gdf, mock_power_by_day = (
             self._make_mock_feed_and_trips()
         )
         mock_fetch_counties.return_value = mock_county_gdf
-        mock_get_hourly.return_value = mock_hourly_temp
+        mock_load_power.return_value = mock_power_by_day
 
         # Call without specifying output_dir (previously raised an exception)
         result = add_HVAC_energy(mock_feed, trips_df, output_dir=None)
 
         self.assertIn("hvac_energy_kWh", result.columns)
         self.assertIn("scenario", result.columns)
-        self.assertEqual(len(result), 3)
+        self.assertIn("date", result.columns)
+        self.assertTrue((result["scenario"] == "TMY").all())
+        self.assertEqual(len(result), 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_thermal_energy.py
+++ b/tests/test_thermal_energy.py
@@ -9,6 +9,8 @@ import pandas as pd
 from shapely.geometry import Point
 
 from routee.transit.thermal_energy import (
+    _densest_window,
+    _select_full_year_window,
     add_HVAC_energy,
     compute_HVAC_energy,
     load_thermal_lookup_table,
@@ -75,7 +77,9 @@ class TestThermalEnergy(unittest.TestCase):
         rows = []
         for month, day in [(1, 15), (7, 15)]:
             for hour in range(24):
-                rows.append({"month": month, "day_of_month": day, "hour": hour, "Power": 5.0})
+                rows.append(
+                    {"month": month, "day_of_month": day, "hour": hour, "Power": 5.0}
+                )
         mock_power_by_day = pd.DataFrame(rows)
         return mock_feed, trips_df, mock_county_gdf, mock_power_by_day
 
@@ -102,10 +106,13 @@ class TestThermalEnergy(unittest.TestCase):
         self.assertIn("hvac_energy_kWh", result.columns)
         self.assertIn("scenario", result.columns)
         self.assertIn("date", result.columns)
+        self.assertIn("trip_is_within_gtfs_scope", result.columns)
         # scenario is always "TMY"
         self.assertTrue((result["scenario"] == "TMY").all())
-        # 2 dates × 1 trip = 2 rows
+        # Default (scale_to_year=False) only returns covered dates: 2 rows
         self.assertEqual(len(result), 2)
+        # All rows are within the feed's real scope
+        self.assertTrue(result["trip_is_within_gtfs_scope"].all())
 
     @patch("routee.transit.thermal_energy.fetch_counties_gdf")
     @patch("routee.transit.thermal_energy.download_tmy_files")
@@ -129,8 +136,188 @@ class TestThermalEnergy(unittest.TestCase):
         self.assertIn("hvac_energy_kWh", result.columns)
         self.assertIn("scenario", result.columns)
         self.assertIn("date", result.columns)
+        self.assertIn("trip_is_within_gtfs_scope", result.columns)
         self.assertTrue((result["scenario"] == "TMY").all())
         self.assertEqual(len(result), 2)
+
+
+class TestDateWindowSelection(unittest.TestCase):
+    def test_densest_window_picks_dense_cluster_over_outlier(self) -> None:
+        # 10 dense dates in Jan 2024 + one far-future outlier in 2030
+        dense = pd.date_range("2024-01-01", periods=10, freq="D").tolist()
+        sorted_dates = dense + [pd.Timestamp("2030-06-01")]
+        sorted_dates.sort()
+        start, end = _densest_window(sorted_dates, max_days=365)  # type: ignore[misc]
+        # Dense block should sit inside the chosen window
+        self.assertLessEqual(start, dense[0])
+        self.assertGreaterEqual(end, dense[-1])
+        # The 2030 outlier must be outside the window
+        self.assertGreater(pd.Timestamp("2030-06-01"), end)
+
+    def test_densest_window_handles_past_outlier(self) -> None:
+        # Symmetric case: far-past outlier should be excluded
+        dense = pd.date_range("2024-01-01", periods=10, freq="D").tolist()
+        sorted_dates = [pd.Timestamp("2018-06-01")] + dense
+        sorted_dates.sort()
+        start, end = _densest_window(sorted_dates, max_days=365)  # type: ignore[misc]
+        self.assertLess(pd.Timestamp("2018-06-01"), start)
+        self.assertLessEqual(start, dense[0])
+
+    def test_select_full_year_snaps_to_calendar_year(self) -> None:
+        sorted_dates = pd.date_range("2023-03-01", "2023-08-31", freq="D").tolist()
+        start, end = _select_full_year_window(sorted_dates, max_days=365)
+        self.assertEqual(start, pd.Timestamp("2023-01-01"))
+        self.assertEqual(end, pd.Timestamp("2023-12-31"))
+
+    def test_select_full_year_centers_cross_year_feed(self) -> None:
+        # Dense block spanning two calendar years → should center on midpoint
+        sorted_dates = pd.date_range("2023-10-01", "2024-03-31", freq="D").tolist()
+        start, end = _select_full_year_window(sorted_dates, max_days=365)
+        self.assertNotEqual(start, pd.Timestamp("2023-01-01"))
+        self.assertNotEqual(start, pd.Timestamp("2024-01-01"))
+        # Window covers the full dense block
+        self.assertLessEqual(start, sorted_dates[0])
+        self.assertGreaterEqual(end, sorted_dates[-1])
+
+
+class TestScaleToYear(unittest.TestCase):
+    def _make_mwf_feed_and_trips(
+        self,
+    ) -> tuple[MagicMock, pd.DataFrame, gpd.GeoDataFrame, pd.DataFrame]:
+        """Build a mock feed that serves only Mon/Wed/Fri in early 2023."""
+        mock_feed = MagicMock()
+        mock_feed.stops = pd.DataFrame(
+            {"stop_id": ["S1"], "stop_lat": [40.0], "stop_lon": [-105.0]}
+        )
+        mock_feed.stop_times = pd.DataFrame(
+            {
+                "trip_id": ["T1", "T1"],
+                "arrival_time": [pd.Timedelta(hours=8), pd.Timedelta(hours=9)],
+                "stop_id": ["S1", "S1"],
+            }
+        )
+        # Real service: Mon/Wed/Fri across two weeks of Jan 2023.
+        # 2023-01-02 (Mon), 01-04 (Wed), 01-06 (Fri),
+        # 2023-01-09 (Mon), 01-11 (Wed), 01-13 (Fri)
+        real_dates = pd.to_datetime(
+            [
+                "2023-01-02",
+                "2023-01-04",
+                "2023-01-06",
+                "2023-01-09",
+                "2023-01-11",
+                "2023-01-13",
+            ]
+        )
+        weekdays = [d.day_name().lower() for d in real_dates]
+        mock_feed.get_service_ids_all_dates.return_value = pd.DataFrame(
+            {
+                "date": real_dates,
+                "service_id": ["S1"] * 6,
+                "weekday": weekdays,
+            }
+        )
+        # Typical service: only Mon/Wed/Fri have any service_id
+        mock_feed.get_typical_service_by_weekday.return_value = pd.DataFrame(
+            {
+                "service_id": [frozenset({"S1"})] * 3,
+                "n_dates": [2, 2, 2],
+            },
+            index=pd.Index(["monday", "wednesday", "friday"], name="weekday"),
+        )
+        trips_df = pd.DataFrame({"trip_id": ["T1"], "service_id": ["S1"]})
+        mock_county_gdf = gpd.GeoDataFrame(
+            {
+                "county_id": ["G0800130"],
+                "STATEFP": ["08"],
+                "COUNTYFP": ["013"],
+                "geometry": [Point(-105.0, 40.0).buffer(1.0)],
+            },
+            crs="EPSG:4269",
+        )
+        # Synthetic per-day power table covering every (month, day_of_month)
+        # in a non-leap year.
+        rows = []
+        for ts in pd.date_range("2023-01-01", "2023-12-31", freq="D"):
+            for hour in range(24):
+                rows.append(
+                    {
+                        "month": ts.month,
+                        "day_of_month": ts.day,
+                        "hour": hour,
+                        "Power": 5.0,
+                    }
+                )
+        mock_power_by_day = pd.DataFrame(rows)
+        return mock_feed, trips_df, mock_county_gdf, mock_power_by_day
+
+    @patch("routee.transit.thermal_energy.fetch_counties_gdf")
+    @patch("routee.transit.thermal_energy.download_tmy_files")
+    @patch("routee.transit.thermal_energy.load_tmy_power_by_day")
+    def test_scale_to_year_projects_only_to_feed_weekdays(
+        self,
+        mock_load_power: MagicMock,
+        mock_download: MagicMock,
+        mock_fetch_counties: MagicMock,
+    ) -> None:
+        mock_feed, trips_df, mock_county_gdf, mock_power_by_day = (
+            self._make_mwf_feed_and_trips()
+        )
+        mock_fetch_counties.return_value = mock_county_gdf
+        mock_load_power.return_value = mock_power_by_day
+
+        result = add_HVAC_energy(
+            mock_feed, trips_df, output_dir=None, scale_to_year=True
+        )
+
+        # Window snaps to 2023 calendar year (all real dates in 2023).
+        # 2023-01-01 is a Sunday → no service projected, so the first
+        # produced date is the first Monday (2023-01-02); likewise the
+        # last day is the last Friday on/before Dec 31 (2023-12-29).
+        self.assertGreaterEqual(result["date"].min(), pd.Timestamp("2023-01-01"))
+        self.assertLessEqual(result["date"].max(), pd.Timestamp("2023-12-31"))
+        # Every produced date must be a Mon/Wed/Fri (the feed's only service days)
+        weekday_nums = result["date"].dt.weekday.unique()
+        # 0=Mon, 2=Wed, 4=Fri
+        self.assertEqual(set(weekday_nums.tolist()), {0, 2, 4})
+        # Real (covered) dates have flag True, synthesized ones False
+        real_dates = {
+            pd.Timestamp(d)
+            for d in [
+                "2023-01-02",
+                "2023-01-04",
+                "2023-01-06",
+                "2023-01-09",
+                "2023-01-11",
+                "2023-01-13",
+            ]
+        }
+        for _, row in result.iterrows():
+            if row["date"] in real_dates:
+                self.assertTrue(row["trip_is_within_gtfs_scope"])
+            else:
+                self.assertFalse(row["trip_is_within_gtfs_scope"])
+
+    @patch("routee.transit.thermal_energy.fetch_counties_gdf")
+    @patch("routee.transit.thermal_energy.download_tmy_files")
+    @patch("routee.transit.thermal_energy.load_tmy_power_by_day")
+    def test_scale_to_year_false_leaves_output_unchanged(
+        self,
+        mock_load_power: MagicMock,
+        mock_download: MagicMock,
+        mock_fetch_counties: MagicMock,
+    ) -> None:
+        mock_feed, trips_df, mock_county_gdf, mock_power_by_day = (
+            self._make_mwf_feed_and_trips()
+        )
+        mock_fetch_counties.return_value = mock_county_gdf
+        mock_load_power.return_value = mock_power_by_day
+
+        result = add_HVAC_energy(mock_feed, trips_df, output_dir=None)
+
+        # Only the 6 real dates appear, all flagged True
+        self.assertEqual(len(result), 6)
+        self.assertTrue(result["trip_is_within_gtfs_scope"].all())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Overview
This pull request updates the HVAC energy modeling to handle a broader range of weather conditions, replacing the `winter`, `summer`, and `median` weather scenarios with date-specific predictions instead, still based on TMY data.

The range of dates covered depends on the GTFS data and a new `scale_to_year`argument in `GFTSEnergyPredictor.run()`. If `scale_to_year=False` (default), then predictions will be generated for all dates covered by the GTFS dataset as defined in the `calendar.txt` and `calendar_dates.txt` (note that the optional `feed_start_date` and `feed_end_date` in `feed_info.txt` are currently ignored). If `scale_to_year=False`, then one year of dates will be included, which requires either downselecting to one year of dates if the feed covers more than one year, or estimating service outside the provided dates if the feed covers less than one year.

For a given `trip_id`, we only predict its energy consumption on dates it's scheduled to run. So, if trip ID `A1` runs on `7/3/2026` and `7/5/2026` but not `7/4/2026`, the results won't include an energy prediction with `date=7/5/2026` and `trip_id=A1`, but will have predictions for the 3rd and 5th.

We handle scaling up feeds with < 1 year of service by identifying the typical service for each day of the week and extrapolating that service to all remaining days of the year. So, all weeks outside of the scope of the GTFS dataset will have the same service pattern. Holidays aren't yet accounted for.

Finally, note that if the `date` argument is specified in `GTFSEnergyPredictor.run()`, we now only generate energy predictions for that specific date (we won't make energy predictions that map that date's service to other days' weather conditions). 

## Trip-Level Results File Changes
A new `trip_is_within_gtfs_scope` results column identifies whether the trip/date combination is actually identified in the GTFS data (`True`) or we've created this trip by scaling up the feed (`False`).

The three previous scenarios (which each corresponded to one day's worth of TMY data) have been replaced with an additional `date` field in the results table. The `scenario` column is retained, always set to `TMY` for now, to leave the option open in the future to use other weather data besides TMY.




