### PR TITLE
Populate `agency_id` and `route_short_name` fields for mid-block deadhead trips

### DIFF
--- a/routee/transit/mid_block_deadhead.py
+++ b/routee/transit/mid_block_deadhead.py
@@ -76,7 +76,7 @@ def create_mid_block_deadhead_trips(
         dh_dfs.append(block_df)
     deadhead_trips = pd.concat(dh_dfs).reset_index(drop=True)
 
-    deadhead_trips["route_short_name"] = None
+    deadhead_trips["route_short_name"] = deadhead_trips["route_id"]
     deadhead_trips["route_type"] = 3
     deadhead_trips["route_desc"] = "Deadhead_from_" + deadhead_trips["trip_id"]
     deadhead_trips["shape_id"] = deadhead_trips["trip_id"]

--- a/routee/transit/mid_block_deadhead.py
+++ b/routee/transit/mid_block_deadhead.py
@@ -68,9 +68,10 @@ def create_mid_block_deadhead_trips(
         to_stop = block_df["to_trip"].map(first_stop_per_trip).astype(str)
         block_df["route_id"] = "deadhead_" + from_stop + "_to_" + to_stop
 
-        block_df = block_df[
-            ["deadhead_trip", "route_id", "service_id", "block_id", "shape_id"]
-        ]
+        cols = ["deadhead_trip", "route_id", "service_id", "block_id", "shape_id"]
+        if "agency_id" in block_df.columns:
+            cols.append("agency_id")
+        block_df = block_df[cols]
         block_df = block_df.rename(columns=({"deadhead_trip": "trip_id"}))
         dh_dfs.append(block_df)
     deadhead_trips = pd.concat(dh_dfs).reset_index(drop=True)
@@ -78,7 +79,6 @@ def create_mid_block_deadhead_trips(
     deadhead_trips["route_short_name"] = None
     deadhead_trips["route_type"] = 3
     deadhead_trips["route_desc"] = "Deadhead_from_" + deadhead_trips["trip_id"]
-    deadhead_trips["agency_id"] = None
     deadhead_trips["shape_id"] = deadhead_trips["trip_id"]
     deadhead_trips["trip_type"] = "mid_block_deadhead"
 

--- a/routee/transit/mid_block_deadhead.py
+++ b/routee/transit/mid_block_deadhead.py
@@ -4,6 +4,23 @@ from geopy.distance import geodesic
 from gtfsblocks import Feed
 
 
+def _empty_mid_block_deadhead_trips(include_agency_id: bool) -> pd.DataFrame:
+    columns = [
+        "trip_id",
+        "route_id",
+        "service_id",
+        "block_id",
+        "shape_id",
+        "route_short_name",
+        "route_type",
+        "route_desc",
+        "trip_type",
+    ]
+    if include_agency_id:
+        columns.insert(5, "agency_id")
+    return pd.DataFrame(columns=columns)
+
+
 def create_mid_block_deadhead_trips(
     trips_df: pd.DataFrame, stop_times_df: pd.DataFrame
 ) -> pd.DataFrame:
@@ -74,8 +91,11 @@ def create_mid_block_deadhead_trips(
         block_df = block_df[cols]
         block_df = block_df.rename(columns=({"deadhead_trip": "trip_id"}))
         dh_dfs.append(block_df)
-    deadhead_trips = pd.concat(dh_dfs).reset_index(drop=True)
 
+    if not dh_dfs:
+        return _empty_mid_block_deadhead_trips("agency_id" in trips_df.columns)
+
+    deadhead_trips = pd.concat(dh_dfs).reset_index(drop=True)
     deadhead_trips["route_short_name"] = deadhead_trips["route_id"]
     deadhead_trips["route_type"] = 3
     deadhead_trips["route_desc"] = "Deadhead_from_" + deadhead_trips["trip_id"]

--- a/tests/test_depot_deadhead.py
+++ b/tests/test_depot_deadhead.py
@@ -86,6 +86,33 @@ class TestCreateDepotDeadheadTrips(unittest.TestCase):
         # All route types should be 3 (bus)
         self.assertTrue(all(result["route_type"] == 3))
 
+    def test_agency_id_propagated_from_first_and_last_trip(self) -> None:
+        result = create_depot_deadhead_trips(self.trips_df, self.stop_times_df)
+
+        # pull-out trips should inherit agency_id from the first revenue trip of
+        # the block; pull-in trips from the last revenue trip.
+        self.assertIn("agency_id", result.columns)
+
+        for _, row in result.iterrows():
+            block = row["block_id"]
+            expected = self.trips_df.loc[
+                self.trips_df["block_id"] == block, "agency_id"
+            ].iloc[0]
+            self.assertEqual(
+                row["agency_id"],
+                expected,
+                msg=f"agency_id mismatch for {row['trip_id']}",
+            )
+
+    def test_agency_id_none_when_absent_from_trips(self) -> None:
+        trips_no_agency = self.trips_df.drop(columns=["agency_id"])
+        result = create_depot_deadhead_trips(trips_no_agency, self.stop_times_df)
+
+        # agency_id column should still exist but be None/NaN when not present
+        # in the source trips (get() fallback returns None).
+        self.assertIn("agency_id", result.columns)
+        self.assertTrue(result["agency_id"].isna().all())
+
     def test_create_depot_deadhead_trips_with_existing_deadhead(self) -> None:
         # Add a between-trip deadhead to trips
         trips_with_deadhead = self.trips_df.copy()

--- a/tests/test_mid_block_deadhead.py
+++ b/tests/test_mid_block_deadhead.py
@@ -63,6 +63,28 @@ class TestMidBlockDeadhead(unittest.TestCase):
         # T1 last stop is S2, T2 first stop is S3
         self.assertEqual(deadhead_trips.iloc[0]["route_id"], "deadhead_S2_to_S3")
 
+    def test_agency_id_propagated_when_present(self) -> None:
+        trips_with_agency = self.trips_df.copy()
+        trips_with_agency["agency_id"] = ["A1", "A1", "A2"]
+
+        deadhead_trips = create_mid_block_deadhead_trips(
+            trips_with_agency, self.stop_times_df
+        )
+
+        # T1 and T2 are in the same block; the deadhead trip T1_to_T2 should
+        # inherit agency_id from T1 (the preceding revenue trip).
+        self.assertIn("agency_id", deadhead_trips.columns)
+        self.assertEqual(deadhead_trips.iloc[0]["agency_id"], "A1")
+
+    def test_agency_id_absent_when_not_in_trips(self) -> None:
+        # trips_df has no agency_id column — function must not crash
+        deadhead_trips = create_mid_block_deadhead_trips(
+            self.trips_df, self.stop_times_df
+        )
+
+        # agency_id column is absent when the input trips have no agency_id
+        self.assertNotIn("agency_id", deadhead_trips.columns)
+
     def test_create_mid_block_deadhead_stops(self) -> None:
         deadhead_trips = create_mid_block_deadhead_trips(
             self.trips_df, self.stop_times_df

--- a/tests/test_mid_block_deadhead.py
+++ b/tests/test_mid_block_deadhead.py
@@ -62,6 +62,10 @@ class TestMidBlockDeadhead(unittest.TestCase):
         # Route ID encodes last stop of from_trip → first stop of to_trip
         # T1 last stop is S2, T2 first stop is S3
         self.assertEqual(deadhead_trips.iloc[0]["route_id"], "deadhead_S2_to_S3")
+        # route_short_name should not be empty
+        self.assertEqual(
+            deadhead_trips.iloc[0]["route_short_name"], "deadhead_S2_to_S3"
+        )
 
     def test_agency_id_propagated_when_present(self) -> None:
         trips_with_agency = self.trips_df.copy()

--- a/tests/test_mid_block_deadhead.py
+++ b/tests/test_mid_block_deadhead.py
@@ -89,6 +89,42 @@ class TestMidBlockDeadhead(unittest.TestCase):
         # agency_id column is absent when the input trips have no agency_id
         self.assertNotIn("agency_id", deadhead_trips.columns)
 
+    def test_no_deadheads_returns_empty_dataframe(self) -> None:
+        trips_no_deadheads = self.trips_df.copy()
+        trips_no_deadheads["block_id"] = ["B1", "B2", "B3"]
+
+        deadhead_trips = create_mid_block_deadhead_trips(
+            trips_no_deadheads, self.stop_times_df
+        )
+
+        self.assertTrue(deadhead_trips.empty)
+        self.assertListEqual(
+            deadhead_trips.columns.tolist(),
+            [
+                "trip_id",
+                "route_id",
+                "service_id",
+                "block_id",
+                "shape_id",
+                "route_short_name",
+                "route_type",
+                "route_desc",
+                "trip_type",
+            ],
+        )
+
+    def test_no_deadheads_preserves_agency_id_column_when_present(self) -> None:
+        trips_with_agency = self.trips_df.copy()
+        trips_with_agency["agency_id"] = ["A1", "A2", "A3"]
+        trips_with_agency["block_id"] = ["B1", "B2", "B3"]
+
+        deadhead_trips = create_mid_block_deadhead_trips(
+            trips_with_agency, self.stop_times_df
+        )
+
+        self.assertTrue(deadhead_trips.empty)
+        self.assertIn("agency_id", deadhead_trips.columns)
+
     def test_create_mid_block_deadhead_stops(self) -> None:
         deadhead_trips = create_mid_block_deadhead_trips(
             self.trips_df, self.stop_times_df


### PR DESCRIPTION
Previously, mid-block deadhead trips had no `agency_id` or `route_short_name` values in results. This small PR updates them so that `agency_id` is set appropriately (based on the actual GTFS trips around the deadhead trip) and also gives a `route_short_name` value, set to be same as the synthetic `route_id`.